### PR TITLE
Fix an error with compatibility

### DIFF
--- a/bin/muon
+++ b/bin/muon
@@ -5,7 +5,7 @@ require 'muon'
 require 'muon/app'
 require 'gli'
 
-include GLI
+include GLI::App
 
 program_desc 'muon tracks your working time'
 version Muon::VERSION
@@ -100,4 +100,4 @@ end
 
 @app = Muon::App.new(Dir.pwd)
 
-exit GLI.run(@app.dealiasify(ARGV))
+exit run(@app.dealiasify(ARGV))


### PR DESCRIPTION
I wanted to try muon, I installed it, and...

```
swistak35@raptop> gem install muon
Fetching: muon-0.0.1.gem (100%)
Successfully installed muon-0.0.1
1 gem installed
Installing ri documentation for muon-0.0.1...
Installing RDoc documentation for muon-0.0.1...

swistak35@raptop> cd one_of_my_projects

swistak35@raptop> muon init
You should include GLI::App instead
GLI.run no longer works for GLI-2, you must just call `run(ARGV)' instead
either fix your app, or use the latest GLI in the 1.x family
```

So, here is the fix. Or maybe I am just doing sth wrong.
Tests are passing : )

```
Started
...............
Finished in 0.083369 seconds.
15 tests, 29 assertions, 0 failures, 0 errors, 0 skips
```
